### PR TITLE
Mark as Gnome 47 compatible

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,8 @@
   "name": "gBinaryClock",
   "shell-version": [
     "45",
-    "46"
+    "46",
+    "47"
   ],
   "url": "https://github.com/Isopolito/gBinaryClock",
   "uuid": "gbinaryclock@isopolito",


### PR DESCRIPTION
It works with Fedora 41.

You could probably release a new version to https://extensions.gnome.org/